### PR TITLE
お悩み相談：編集、削除機能追加

### DIFF
--- a/app/controllers/consultations_controller.rb
+++ b/app/controllers/consultations_controller.rb
@@ -11,7 +11,7 @@ class ConsultationsController < ApplicationController
   def create
     @consultation = current_user.consultations.build(consultation_params)
     if @consultation.save
-      redirect_to consultations_path, notice: t("defaults.flash_message.created", item: Consultation.model_name.human)
+      redirect_to consultation_path(@consultation), notice: t("defaults.flash_message.created", item: Consultation.model_name.human)
     else
       flash.now[:alert] = t("defaults.flash_message.not_created", item: Consultation.model_name.human)
       render :new, status: :unprocessable_entity
@@ -22,6 +22,26 @@ class ConsultationsController < ApplicationController
     @consultation = Consultation.find(params[:id])
     @comment = Comment.new
     @comments = @consultation.comments.includes(:user).order(created_at: :desc)
+  end
+
+  def edit
+    @consultation = current_user.consultations.find(params[:id])
+  end
+
+  def update
+    @consultation = current_user.consultations.find(params[:id])
+    if @consultation.update(consultation_params)
+      redirect_to consultation_path(@consultation), notice: t("defaults.flash_message.updated", item: Consultation.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.mot_updated", item: Consultation.model_name.human)
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    consultation = current_user.consultations.find(params[:id])
+    consultation.destroy!
+    redirect_to consultations_path, notice: t("defaults.flash_message.deleted", item: Consultation.model_name.human)
   end
 
   private

--- a/app/views/consultations/_form.html.erb
+++ b/app/views/consultations/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: consultation, local: true do |f| %>
+<div class="mb-3 p-4">
+  <%= f.label :title, class: "font-bold mb-3 block" do %>
+  タイトル
+  <span class="text-red-500">*</span>
+  <% end %>
+  <%= f.text_field :title, class: "input w-full text-md input-lg input-secondary p-2 h-15", placeholder: "タイトルは必須です"%>
+</div>
+<div class="mb-3">
+  <%= f.label :content, class: "font-bold mb-3 block" do %>
+  本文
+  <span class="text-red-500">*</span>
+  <% end %>
+  <%= f.text_area :content, class: "input w-full input-lg input-secondary p-2 h-80 resize-y", placeholder: "本文は必須です" %>
+</div>
+<%= f.submit "投稿する", class: "btn btn-md btn-secondary" %>
+<% end %>

--- a/app/views/consultations/edit.html.erb
+++ b/app/views/consultations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="w-full sm:w-full md:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto mt-6">
   <div class="flex flex-col text-center mb-6 w-full">
     <h1 class=" text-xl font-medium text-left">
-      <i class="far fa-comment-dots"></i>お悩み相談新規作成
+      <i class="far fa-comment-dots"></i>お悩み相談:編集
     </h1>
     <%= render "form", consultation: @consultation %>
   </div>

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -11,8 +11,8 @@
             <%= image_tag "dog.png", class: "w-14 h-14 rounded-full flex-shrink-0 flex items-center justify-center" %>
             <div class="flex ml-auto space-x-2">
               <% if  user_signed_in? && current_user.own?(@consultation) %>
-              <%= link_to "編集", "#", class:"btn px-2 py-1 btn-accent" %>
-              <%= link_to "削除", "#", class:"btn px-2 py-1 btn-error" %>
+              <%= link_to "編集", edit_consultation_path(@consultation), class:"btn px-2 py-1 btn-accent" %>
+              <%= link_to "削除", consultation_path(@consultation), data: { turbo_method: :delete, turco_confirm: t("defaults.delete_confirm") }, class:"btn px-2 py-1 btn-error" %>
               <% end %>
             </div>
           </div>

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -12,7 +12,7 @@
             <div class="flex ml-auto space-x-2">
               <% if  user_signed_in? && current_user.own?(@consultation) %>
               <%= link_to "編集", edit_consultation_path(@consultation), class:"btn px-2 py-1 btn-accent" %>
-              <%= link_to "削除", consultation_path(@consultation), data: { turbo_method: :delete, turco_confirm: t("defaults.delete_confirm") }, class:"btn px-2 py-1 btn-error" %>
+              <%= link_to "削除", consultation_path(@consultation), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class:"btn px-2 py-1 btn-error" %>
               <% end %>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
         <%= render 'shared/sidebar_menu' %>
       </aside>
 
-      <main class="flex-1 px-4 py-0 mt-0">
+      <main class="flex-1 px-4 py-1 mt-1">
         <%= render "shared/flash_message" %>
         <%= yield %>
       </main>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
         <%= render 'shared/sidebar_menu' %>
       </aside>
 
-      <main class="flex-1 px-4 py-1 mt-1">
+      <main class="flex-1 px-4 py-0 mt-0">
         <%= render "shared/flash_message" %>
         <%= yield %>
       </main>


### PR DESCRIPTION
お悩み相談の編集機能、削除機能を追加しました

- 一覧の投稿をクリックすると自分の投稿なら編集、削除ボタンが表示されます。
- 編集クリックすると編集画面に遷移、削除ボタンはアラートが出るように設定しています。
- 編集後は詳細画面、削除後は一覧画面に遷移するようにしています。

Closed #13 #48 