### PR TITLE
お悩み相談:リアクション機能追加

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,0 +1,15 @@
+class ReactionsController < ApplicationController
+  def create
+    @consultation = Consultation.find(params[:consultation_id])
+    @reaction = @consultation.reactions.find_or_initialize_by(user: current_user, reaction_category: params[:reaction_category])
+    if @reaction.persisted?
+      @reaction.destroy
+    else
+      @reaction.save
+    end
+    respond_to do |format|
+      format.turbo_stream  # これを明示的に指定
+      format.html { redirect_to @consultation }
+    end
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,7 +60,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # The path used after sign up.
   # 新規登録後にリダイレクトされるパスを指定する。superだとデフォルトのリダイレクト先
   def after_sign_up_path_for(resource)
-    super(resource)
+    root_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -29,4 +29,8 @@ class Users::SessionsController < Devise::SessionsController
   # def after_sign_up_path_for(resource_or_scope)
   #   new_user_session_path
   # end
+
+  def after_sign_in_path_for(resource)
+  root_path
+  end
 end

--- a/app/helpers/reactions_helper.rb
+++ b/app/helpers/reactions_helper.rb
@@ -1,0 +1,11 @@
+module ReactionsHelper
+  def reaction_icons
+    {
+      "cheer"   => ["fa-hands-clapping", "応援"],
+      "empathy" => ["fa-heart", "共感"],
+      "amazing" => ["fa-star", "すごい"],
+      "cry"     => ["fa-face-sad-tear", "泣ける"],
+      "laugh"   => ["fa-face-laugh-squint", "笑った"]
+    }
+  end
+end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -5,4 +5,5 @@ class Consultation < ApplicationRecord
 
   belongs_to :user
   has_many :comments, dependent: :destroy
+  has_many :reactions, dependent: :destroy
 end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,0 +1,8 @@
+class Reaction < ApplicationRecord
+  validates :reaction_type, presence: true
+  validates :user_id, uniqueness: { scope: [:consultation_id, :reaction_type] }
+  belongs_to :user
+  belongs_to :consultation
+
+  enum reaction_type: { cheer: 0, empathy: 1, amazing: 2, cry: 3, laugh: 4 }
+end

--- a/app/models/reaction.rb
+++ b/app/models/reaction.rb
@@ -1,8 +1,8 @@
 class Reaction < ApplicationRecord
-  validates :reaction_type, presence: true
-  validates :user_id, uniqueness: { scope: [:consultation_id, :reaction_type] }
+  validates :reaction_category, presence: true
+  validates :user_id, uniqueness: { scope: [:consultation_id, :reaction_category] }
   belongs_to :user
   belongs_to :consultation
 
-  enum reaction_type: { cheer: 0, empathy: 1, amazing: 2, cry: 3, laugh: 4 }
+  enum reaction_category: { cheer: 0, empathy: 1, amazing: 2, cry: 3, laugh: 4 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
 
   has_many :consultations, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :reactions, dependent: :destroy
   def own?(resource)
     id == resource&.user_id
   end

--- a/app/views/consultations/_form.html.erb
+++ b/app/views/consultations/_form.html.erb
@@ -1,21 +1,21 @@
 <%= form_with model: consultation, local: true do |f| %>
-<div class="mb-3 p-4">
+<div class="mb-3">
   <%= f.label :title, class: "font-bold mb-3 block" do %>
   タイトル
   <span class="text-red-500">*</span>
   <% end %>
-  <%= f.text_field :title, class: "input w-full text-md input-lg input-secondary p-2 h-15", placeholder: "タイトルは必須です"%>
+  <%= f.text_field :title, class: "input w-full input-secondary p-2 h-15", placeholder: "タイトルは必須です"%>
 </div>
 <div class="mb-3">
   <%= f.label :content, class: "font-bold mb-3 block" do %>
   本文
   <span class="text-red-500">*</span>
   <% end %>
-  <%= f.text_area :content, class: "input w-full input-lg input-secondary p-2 h-80 resize-y", placeholder: "本文は必須です" %>
+  <%= f.text_area :content, class: "input w-full input-secondary p-2 h-80 resize-y leading-1", placeholder: "本文は必須です" %>
 </div>
-<div class="mb-3 p-4">
+<div class="mb-3">
   <%= f.label :tag_list, class: "font-bold mb-3 block"%>
-  <%= f.text_field :tag_list, value: consultation.tag_list.join('#'), class: "input w-full text-md input-lg input-secondary p-2 h-15", placeholder: "例）#吠え#散歩"%>
+  <%= f.text_field :tag_list, value: consultation.tag_list.join('#'), class: "input w-full text-md input-secondary p-2 h-15", placeholder: "例）#吠え#散歩"%>
 </div>
 <%= f.submit "投稿する", class: "btn btn-md btn-secondary" %>
 <% end %>

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -31,19 +31,21 @@
           </div>
           <p class="card-text"><%= @consultation.content %></p>
         </div>
+        <!-- リアクションボタン -->
+        <%= render "reactions/reactions", consultation: @consultation %>
       </div>
     </div>
-    <!-- コメントフォーム -->
-    <%= render partial: "comments/form", locals: { comment: @comment, consultation: @consultation } %>
-    <div class="row">
-      <div class="col-lg-8 offset-lg-2">
-        <table class="table">
-          <tbody id="table-comment">
-            <!-- コメント一覧 -->
-            <%= render partial: "comments/comment", collection: @comments %>
-          </tbody>
-        </table>
-      </div>
+  </div>
+  <!-- コメントフォーム -->
+  <%= render partial: "comments/form", locals: { comment: @comment, consultation: @consultation } %>
+  <div class="row">
+    <div class="col-lg-8 offset-lg-2">
+      <table class="table">
+        <tbody id="table-comment">
+          <!-- コメント一覧 -->
+          <%= render partial: "comments/comment", collection: @comments %>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>

--- a/app/views/consultations/show.html.erb
+++ b/app/views/consultations/show.html.erb
@@ -29,7 +29,7 @@
               <%= render "tag_list", tag_list: @consultation.tag_list %>
             </div>
           </div>
-          <p class="card-text"><%= @consultation.content %></p>
+          <p class="text-left"><%= simple_format(@consultation.content) %></p>
         </div>
         <!-- リアクションボタン -->
         <%= render "reactions/reactions", consultation: @consultation %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
   <link rel="apple-touch-icon" href="/icon.png">
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
+  <%= turbo_include_tags %>
 </head>
 
 <body class="min-h-screen bg-gradient-to-b from-[#F6F8F7] to-[#F7F6E4]">

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -1,11 +1,11 @@
 <div id="reactions-<%= consultation.id %>" class="flex flex-col gap-2">
-  <div class="flex gap-3 flex-wrap">
+  <div class="flex gap-3 flex-wrap mt-4">
     <% Reaction.reaction_categories.keys.each do |category| %>
     <% reacted = consultation.reactions.exists?(user: current_user, reaction_category: category) %>
     <%= button_to consultation_reactions_path(consultation, reaction_category: category),
       method: :post,
       data: { turbo_stream: true },
-      class: "btn btn-sm gap-1 transition-all duration-300 #{reacted ? "btn-primary transform scale-105" : "btn-outline hover:btn-primary"}" do %>
+      class: "btn btn-xs gap-1 transition-all duration-300 #{reacted ? "btn-primary transform scale-105" : "btn-outline hover:btn-primary"} text-xs px-2 py-1" do %>
     <i class="fa-solid <%= reaction_icons[category][0] %>"></i>
     <span><%= reaction_icons[category][1] %></span>
     <% end %>
@@ -15,7 +15,7 @@
     <% reaction_icons.each do |category, (icon_class,label)| %>
     <% count = consultation.reactions.where(reaction_category: category).count %>
     <% next if count.zero? %>
-    <span class="flex items-center gap-1">
+    <span class="flex items-center gap-1 text-xs">
       <i class="fa-solid <%= icon_class %>"></i>
       <span><%= count %></span>
     </span>

--- a/app/views/reactions/_reactions.html.erb
+++ b/app/views/reactions/_reactions.html.erb
@@ -1,0 +1,24 @@
+<div id="reactions-<%= consultation.id %>" class="flex flex-col gap-2">
+  <div class="flex gap-3 flex-wrap">
+    <% Reaction.reaction_categories.keys.each do |category| %>
+    <% reacted = consultation.reactions.exists?(user: current_user, reaction_category: category) %>
+    <%= button_to consultation_reactions_path(consultation, reaction_category: category),
+      method: :post,
+      data: { turbo_stream: true },
+      class: "btn btn-sm gap-1 transition-all duration-300 #{reacted ? "btn-primary transform scale-105" : "btn-outline hover:btn-primary"}" do %>
+    <i class="fa-solid <%= reaction_icons[category][0] %>"></i>
+    <span><%= reaction_icons[category][1] %></span>
+    <% end %>
+    <% end %>
+  </div>
+  <div class="mt-3 text-sm flex gap-3 flex-wrap">
+    <% reaction_icons.each do |category, (icon_class,label)| %>
+    <% count = consultation.reactions.where(reaction_category: category).count %>
+    <% next if count.zero? %>
+    <span class="flex items-center gap-1">
+      <i class="fa-solid <%= icon_class %>"></i>
+      <span><%= count %></span>
+    </span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reactions/create.turbo_stream.erb
+++ b/app/views/reactions/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "reactions-#{@consultation.id}" do %>
+  <%= render "reactions/reactions", consultation: @consultation %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   resources :consultations, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     resources :comments, only: [ :create, :edit, :destroy ], shallow: true
+    resources :reactions, only: [ :create ]
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20250818044609_create_reactions.rb
+++ b/db/migrate/20250818044609_create_reactions.rb
@@ -1,0 +1,11 @@
+class CreateReactions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reactions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :consultation, null: false, foreign_key: true
+      t.integer :reaction_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250818232505_rename_reaction_type_column_to_reactions.rb
+++ b/db/migrate/20250818232505_rename_reaction_type_column_to_reactions.rb
@@ -1,0 +1,5 @@
+class RenameReactionTypeColumnToReactions < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :reactions, :reaction_type, :reaction_category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_18_002344) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_18_232505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_18_002344) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_consultations_on_user_id"
+  end
+
+  create_table "reactions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "consultation_id", null: false
+    t.integer "reaction_category"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["consultation_id"], name: "index_reactions_on_consultation_id"
+    t.index ["user_id"], name: "index_reactions_on_user_id"
   end
 
   create_table "taggings", force: :cascade do |t|
@@ -94,5 +104,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_18_002344) do
   add_foreign_key "consultation_comments", "consultations"
   add_foreign_key "consultation_comments", "users"
   add_foreign_key "consultations", "users"
+  add_foreign_key "reactions", "consultations"
+  add_foreign_key "reactions", "users"
   add_foreign_key "taggings", "tags"
 end

--- a/test/controllers/reactions_controller_test.rb
+++ b/test/controllers/reactions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReactionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/reactions.yml
+++ b/test/fixtures/reactions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  consultation: one
+  reaction_type: 1
+
+two:
+  user: two
+  consultation: two
+  reaction_type: 1

--- a/test/fixtures/reactions.yml
+++ b/test/fixtures/reactions.yml
@@ -3,9 +3,9 @@
 one:
   user: one
   consultation: one
-  reaction_type: 1
+  reaction_category: 1
 
 two:
   user: two
   consultation: two
-  reaction_type: 1
+  reaction_category: 1

--- a/test/models/reaction_test.rb
+++ b/test/models/reaction_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReactionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
お悩み相談のリアクション機能を追加しました。

- カラム名がreaction_typeとSTIで予約語になる可能性のものを使用してしまっていたのでreaction_categoryに変更しました。
- リアクションは5つ(応援・共感・すごい・泣いた・笑った)です
- Turbosteamで機能するよう設定しています
- 本番環境でログイン後のリダイレクト先がConsultation#newとなってしまうことがあったので明示的に指定してrootになるようにしました
