### PR TITLE
チャット:モデル作成

### DIFF
--- a/app/models/chat_message.rb
+++ b/app/models/chat_message.rb
@@ -1,0 +1,6 @@
+class ChatMessage < ApplicationRecord
+  validates :content, presence: true
+
+  belongs_to :user
+  belongs_to :chat_room
+end

--- a/app/models/chat_room.rb
+++ b/app/models/chat_room.rb
@@ -1,0 +1,17 @@
+class ChatRoom < ApplicationRecord
+  has_many :chat_room_users, dependent: :destroy
+  has_many :users, through: :chat_room_users
+  has_many :chat_messages, dependent: :destroy
+
+  # roomの名前表示もし名前があればそれ、2人のuserでチャットするなら自分じゃない方のuserの名前を
+  def display_name(current_user)
+    if name.present?
+      name
+    elsif users.count == 2
+      other_user = users.where.not(id: current_user.id).first
+      other_user&.name || "Unknown User"
+    else
+      users.pluck(:name).join(", ")
+    end
+  end
+end

--- a/app/models/chat_room_user.rb
+++ b/app/models/chat_room_user.rb
@@ -1,0 +1,4 @@
+class ChatRoomUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :chat_room
+end

--- a/db/migrate/20250819054835_create_chat_rooms.rb
+++ b/db/migrate/20250819054835_create_chat_rooms.rb
@@ -1,0 +1,9 @@
+class CreateChatRooms < ActiveRecord::Migration[7.2]
+  def change
+    create_table :chat_rooms do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250819055051_create_chat_messages.rb
+++ b/db/migrate/20250819055051_create_chat_messages.rb
@@ -1,0 +1,11 @@
+class CreateChatMessages < ActiveRecord::Migration[7.2]
+  def change
+    create_table :chat_messages do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :chat_room, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250819055146_create_chat_room_users.rb
+++ b/db/migrate/20250819055146_create_chat_room_users.rb
@@ -1,0 +1,11 @@
+class CreateChatRoomUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :chat_room_users do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :chat_room, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :chat_room_users, [ :chat_room_id, :user_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_18_232505) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_19_055146) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "chat_messages", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "chat_room_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chat_room_id"], name: "index_chat_messages_on_chat_room_id"
+    t.index ["user_id"], name: "index_chat_messages_on_user_id"
+  end
+
+  create_table "chat_room_users", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "chat_room_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["chat_room_id", "user_id"], name: "index_chat_room_users_on_chat_room_id_and_user_id", unique: true
+    t.index ["chat_room_id"], name: "index_chat_room_users_on_chat_room_id"
+    t.index ["user_id"], name: "index_chat_room_users_on_user_id"
+  end
+
+  create_table "chat_rooms", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "comments", force: :cascade do |t|
     t.bigint "user_id"
@@ -99,6 +125,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_18_232505) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "chat_messages", "chat_rooms"
+  add_foreign_key "chat_messages", "users"
+  add_foreign_key "chat_room_users", "chat_rooms"
+  add_foreign_key "chat_room_users", "users"
   add_foreign_key "comments", "consultations"
   add_foreign_key "comments", "users"
   add_foreign_key "consultation_comments", "consultations"

--- a/test/fixtures/chat_messages.yml
+++ b/test/fixtures/chat_messages.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+  user: one
+  chat_room: one
+
+two:
+  content: MyText
+  user: two
+  chat_room: two

--- a/test/fixtures/chat_room_users.yml
+++ b/test/fixtures/chat_room_users.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  chat_room: one
+
+two:
+  user: two
+  chat_room: two

--- a/test/fixtures/chat_rooms.yml
+++ b/test/fixtures/chat_rooms.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/models/chat_message_test.rb
+++ b/test/models/chat_message_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChatMessageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/chat_room_test.rb
+++ b/test/models/chat_room_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChatRoomTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/chat_room_user_test.rb
+++ b/test/models/chat_room_user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ChatRoomUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
チャットのモデルを作成しました。
Chat_rooms テーブル
- id (primary key)
- name (string)
- created_at, updated_at

Chat_room_users テーブル（中間テーブル）
- id (primary key)
- chat_room_id (integer)
- user_id (integer)
- created_at, updated_at

Chat_messages テーブル
- id (primary key)
- chat_room_id (integer)
- user_id (integer)
- content (text)
- created_at, updated_at

上記作成しています。
Closed #46 