### PR TITLE
日記モデル、一覧、新規、詳細作成

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -2,4 +2,28 @@ class DiariesController < ApplicationController
   def index
     @diaries = Diary.includes(:user).order(created_at: :desc)
   end
+
+  def new
+    @diary = Diary.new
+  end
+
+  def create
+    @diary = current_user.diaries.build(diary_params)
+    if @diary.save
+      redirect_to diary_path(@diary), notice: t("defaults.flash_message.created", item: Diary.model_name.human)
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created", item: Diary.model_name.human)
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def show
+    @diary = Diary.find(params[:id])
+  end
+
+  private
+
+  def diary_params
+    params.require(:diary).permit(:written_on, :content, :image)
+  end
 end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,0 +1,5 @@
+class DiariesController < ApplicationController
+  def index
+    @diaries = Diary.includes(:user).order(created_at: :desc)
+  end
+end

--- a/app/helpers/diaries_helper.rb
+++ b/app/helpers/diaries_helper.rb
@@ -1,0 +1,2 @@
+module DiariesHelper
+end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,4 +1,5 @@
 class Diary < ApplicationRecord
   validates :content, presence: true, length: { maximum: 65_535 }
+  validates :written_on, presence: true, uniqueness: { scope: :user_id }
   belongs_to :user
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,0 +1,4 @@
+class Diary < ApplicationRecord
+  validates :content, presence: true, length: { maximum: 65_535 }
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :chat_room_users, dependent: :destroy
   has_many :chat_rooms, through: :chat_room_users
   has_many :chat_messages, dependent: :destroy
+  has_many :diaries, dependent: :destroy
+
   def own?(resource)
     id == resource&.user_id
   end

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,0 +1,20 @@
+<div class="card bg-white shadow-sm p-4 flex flex-col gap-2">
+  <div class="flex justify-between items-center">
+    <!-- 左側: アバター + 名前 -->
+    <div class="flex items-center space-x-2">
+      <%= link_to user_path(diary.user), class: "flex items-center space-x-2" do %>
+      <%= image_tag "dog.png", class: "w-12 h-12 rounded-full" %>
+      <span class="font-normal text-sm hover:underline"><%= diary.user.name %></span>
+      <% end %>
+    </div>
+    <!-- 右側: 日付 -->
+    <span class="text-xs text-gray-600"><%= diary.written_on.strftime("%Y年%m月%d日（%a）") %></span>
+  </div>
+  <!-- カード全体を詳細リンク -->
+  <%= link_to diary_path(diary), class: "block w-full h-full" do %>
+  <div class="flex-1 flex flex-col ml-16">
+    <!-- 本文 -->
+    <p class="text-sm mt-1"><%= truncate(diary.content, length: 80) %></p>
+  </div>
+  <% end %>
+</div>

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with model: diary, local: true do |f| %>
+<div class="mb-3">
+  <%= f.label :written_on, class: "font-bold mb-3 block" do %>
+  日付
+  <span class="text-red-500">*</span>
+  <% end %>
+  <%= f.date_field :written_on, class: "input input-secondary" %>
+</div>
+<div class="mb-3">
+  <%= f.label :content, class: "font-bold mb-3 block" do %>
+  日記
+  <span class="text-red-500">*</span>
+  <% end %>
+  <%= f.text_area :content, class: "input w-full input-secondary p-2 h-80 resize-y leading-1", placeholder: "本文は必須です" %>
+</div>
+<%= f.submit "投稿する", class: "btn btn-md btn-secondary" %>
+<% end %>

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,0 +1,25 @@
+<div class="w-full sm:w-full md:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto mt-6">
+  <div class="flex flex-col text-center mb-6 w-full">
+    <h1 class=" text-xl font-semibold text-left">
+      <i class="far fa-edit"></i>うちの子日記
+    </h1>
+    <h1 class="text-lg border-b border-sky-300 pt-5"> うちの子日記新規作成</h1>
+    <div class="flex justify-center w-full mt-3">
+      <%= link_to "うちの子日記を書く", new_diary_path,class: "btn btn-sm btn-secondary" %>
+    </div>
+    <h1 class="text-lg border-b border-sky-300 pt-5">うちの子日記を見る</h1>
+    <div class="flex justify-center w-full mt-3 gap-2">
+      <%= link_to "MY日記一覧", "#",class: "btn btn-sm btn-secondary" %>
+      <%= link_to "ほかの子の日記を見る", "#",class: "btn btn-sm btn-secondary" %>
+    </div>
+    <h1 class="text-lg border-b border-sky-300 pt-5">新着うちの子日記一覧</h1>
+    <!-- 日記リスト -->
+    <div class="grid grid-cols-1 sm:grid-cols-2">
+      <% if @diaries.present? %>
+      <% @diaries.each do |diary| %>
+      <%= render partial: "diary", locals: { diary: diary } %>
+      <% end %>
+      <% else %>
+      <div class="mb-3 col-span-2">日記はまだありません。ぜひ書いてみてください。</div>
+      <% end %>
+    </div>

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,0 +1,8 @@
+<div class="w-full sm:w-full md:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto mt-6">
+  <div class="flex flex-col text-center mb-6 w-full">
+    <h1 class=" text-xl font-medium text-left">
+      <i class="far fa-edit"></i>うちの子日記新規作成
+    </h1>
+    <%= render "form", diary: @diary %>
+  </div>
+</div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -1,0 +1,34 @@
+<div class="w-full sm:w-full md:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto mt-6">
+  <div class="flex flex-col text-center mb-6 w-full">
+    <h1 class=" text-xl font-semibold text-left">
+      <i class="far fa-edit"></i>日記詳細
+    </h1>
+    <div class="card bg-white shadow-md w-[calc(100%-1rem)] sm:w-[calc(100%-2rem)] md:max-w-md lg:max-w-lg xl:max-w-2xl mx-auto mt-6">
+      <div class="card-body">
+        <div class="flex-1 flex flex-col">
+          <!-- アバターとボタンを横並び -->
+          <div class="flex justify-between items-start mb-1">
+            <%= link_to user_path(@diary.user), class: "flex items-center space-x-2" do %>
+            <%= image_tag "dog.png", class: "w-14 h-14 rounded-full flex-shrink-0 flex items-center justify-center" %>
+            <span class="font-small hover:underline"><%= @diary.user.name %></span>
+            <% end %>
+
+            <div class="flex ml-auto space-x-2">
+              <% if  user_signed_in? && current_user.own?(@diary) %>
+              <%= link_to "編集", edit_diary_path(@diary), class:"btn px-2 py-1 btn-accent" %>
+              <%= link_to "削除", diary_path(@diary), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") }, class:"btn px-2 py-1 btn-error" %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+        <div class="flex-1 flex flex-col">
+          <!-- ユーザー名と日付を横並び -->
+          <div class="flex ml-auto mb-1">
+            <span class="text-gray-500"><%= @diary.written_on.strftime("%Y年%m月%d日(%a)") %></span>
+          </div>
+        </div>
+        <p class="text-left"><%= simple_format(@diary.content) %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 <body class="min-h-screen bg-gradient-to-b from-[#F6F8F7] to-[#F7F6E4]">
   <div class="flex flex-col min-h-screen" data-controller="menu-toggle">
     <%= render 'shared/header' %>
-    <div class="flex relative">
+    <div class="flex relative flex-1">
       <!-- オーバーレイ（モバイル時のみ） -->
       <div data-menu-toggle-target="overlay" data-action="click->menu-toggle#close" class="fixed inset-0 bg-black bg-opacity-50 z-40 hidden lg:hidden"></div>
 

--- a/app/views/shared/_sidebar_menu.html.erb
+++ b/app/views/shared/_sidebar_menu.html.erb
@@ -22,8 +22,8 @@
     </li>
     <% end %>
     <li class="mb-3">
-      <%= link_to "#", class: "btn btn-ghost w-full text-md justify-start border-b-stone-400" do %>
-      <i class="far fa-edit"></i> 日記トップ
+      <%= link_to diaries_path, class: "btn btn-ghost w-full text-md justify-start border-b-stone-400" do %>
+      <i class="far fa-edit"></i> うちの子日記
       <% end %>
     </li>
     <li class="mb-3">
@@ -46,10 +46,14 @@
       <i class="far fa-heart"></i>いぬのきもち診断
       <% end %>
     </li>
+    <%
+=begin%>
     <li class="mb-3">
       <%= link_to "#", class: "btn btn-ghost w-full text-md justify-start border-b-stone-400" do %>
       <i class="far fa-id-card"></i> マイページ
       <% end %>
     </li>
+    <%
+=end%>
   </ul>
 </aside>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -17,7 +17,7 @@
       </p>
       <ul class="menu grid grid-cols-2 gap-2">
         <li>
-          <%= link_to "#", class: "block w-full h-full rounded-lg border-2 border-blue-200 p-3 min-h-[140px] flex flex-col items-center justify-center text-center hover:bg-blue-50 transition" do %>
+          <%= link_to diaries_path, class: "block w-full h-full rounded-lg border-2 border-blue-200 p-3 min-h-[140px] flex flex-col items-center justify-center text-center hover:bg-blue-50 transition" do %>
           <span class="flex items-center gap-2 mb-2 text-md font-bold">
             <i class="far fa-edit"></i> うちの子日記
           </span>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,8 +17,9 @@ ja:
       deleted: "%{item}を削除しました"
   activerecord:
     models:
-      consultation: "お悩み相談"
+      consultation: お悩み相談
       comment: コメント
+      diary: うちの子日記
     attributes:
       consultation:
         title: タイトル
@@ -26,3 +27,7 @@ ja:
         tag_list: タグ
       comment:
         content: コメント
+      diary:
+        content: 日記
+        written_on: 日付
+        image: 画像

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   resources :chat_rooms, only: [ :index, :show, :create ] do
     resources :chat_messages, only: [ :create ]
   end
+  resources :diaries, only: [ :index, :show, :new, :create, :edit ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250824233041_create_diaries.rb
+++ b/db/migrate/20250824233041_create_diaries.rb
@@ -1,7 +1,7 @@
 class CreateDiaries < ActiveRecord::Migration[7.2]
   def change
     create_table :diaries do |t|
-      t.text :content
+      t.text :content, null: false
       t.string :image
       t.references :user, null: false, foreign_key: true
 

--- a/db/migrate/20250824233041_create_diaries.rb
+++ b/db/migrate/20250824233041_create_diaries.rb
@@ -1,11 +1,13 @@
 class CreateDiaries < ActiveRecord::Migration[7.2]
   def change
     create_table :diaries do |t|
+      t.date :written_on, null: false
       t.text :content, null: false
       t.string :image
       t.references :user, null: false, foreign_key: true
 
       t.timestamps
     end
+    add_index :diaries, [ :written_on, :user_id ], unique: true
   end
 end

--- a/db/migrate/20250824233041_create_diaries.rb
+++ b/db/migrate/20250824233041_create_diaries.rb
@@ -1,0 +1,11 @@
+class CreateDiaries < ActiveRecord::Migration[7.2]
+  def change
+    create_table :diaries do |t|
+      t.text :content
+      t.string :image
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_19_055146) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_24_233041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,6 +58,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_19_055146) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_consultations_on_user_id"
+  end
+
+  create_table "diaries", force: :cascade do |t|
+    t.text "content"
+    t.string "image"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_diaries_on_user_id"
   end
 
   create_table "reactions", force: :cascade do |t|
@@ -122,6 +131,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_19_055146) do
   add_foreign_key "comments", "consultations"
   add_foreign_key "comments", "users"
   add_foreign_key "consultations", "users"
+  add_foreign_key "diaries", "users"
   add_foreign_key "reactions", "consultations"
   add_foreign_key "reactions", "users"
   add_foreign_key "taggings", "tags"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,12 +61,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_24_233041) do
   end
 
   create_table "diaries", force: :cascade do |t|
-    t.text "content"
+    t.date "written_on", null: false
+    t.text "content", null: false
     t.string "image"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_diaries_on_user_id"
+    t.index ["written_on", "user_id"], name: "index_diaries_on_written_on_and_user_id", unique: true
   end
 
   create_table "reactions", force: :cascade do |t|

--- a/test/controllers/diaries_controller_test.rb
+++ b/test/controllers/diaries_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DiariesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get diaries_index_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/diaries.yml
+++ b/test/fixtures/diaries.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+  image: MyString
+  user: one
+
+two:
+  content: MyText
+  image: MyString
+  user: two

--- a/test/models/diary_test.rb
+++ b/test/models/diary_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DiaryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
日記機能のモデル作成、一覧表示作成、新規作成フォーム、詳細を作りました。

- 日記の作成日ではなく、日付を選択できるようにしてあります。
- 一覧表示では新規作成の導線、一覧表示まで実装しています。(MY一覧、他の子の日記一覧のリンクはまだ未)
- 画像挿入機能はまだ未です

Closed #21 　Closed #27　Closed #45 